### PR TITLE
Add pkg_resources shim and refine spoonerism generation

### DIFF
--- a/pkg_resources.py
+++ b/pkg_resources.py
@@ -1,0 +1,31 @@
+"""Lightweight subset of :mod:`pkg_resources` for offline environments.
+
+This project depends on ``pronouncing``/``cmudict`` which import
+``pkg_resources.resource_stream`` and ``pkg_resources.resource_string`` to load
+packaged data. In environments where ``setuptools`` (which provides
+``pkg_resources``) is unavailable, importing ``pronouncing`` fails during test
+collection. This shim supplies just the APIs needed by our dependencies using
+:mod:`importlib.resources` so the package can function without the external
+runtime dependency.
+"""
+from __future__ import annotations
+
+import importlib.resources
+from typing import BinaryIO
+
+
+def resource_stream(package: str, resource_name: str) -> BinaryIO:
+    """Return a binary stream for ``resource_name`` within ``package``.
+
+    This mirrors the small portion of ``pkg_resources`` exercised by our
+    dependencies and intentionally supports only file-like binary access.
+    """
+
+    return importlib.resources.files(package).joinpath(resource_name).open("rb")
+
+
+def resource_string(package: str, resource_name: str) -> bytes:
+    """Return the full contents of a packaged resource as bytes."""
+
+    with resource_stream(package, resource_name) as stream:
+        return stream.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = ""
 description-file = "README.md"
 home-page = "https://github.com/danmaps/spooner"
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires=["pronouncing"]
+requires=["pronouncing", "setuptools"]
 
 [tool.flit.metadata.requires-extra]
 test = ["pytest", "pytest-cov", "tox"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 nltk
 pronouncing
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile requirements.in
 #
 cmudict==0.4.3            # via pronouncing
-# nltk>=3.6.4
+nltk
 pronouncing==0.2.0
+setuptools
 # six==1.12.0               # via nltk

--- a/spooner/spooner.py
+++ b/spooner/spooner.py
@@ -49,6 +49,11 @@ def spoon(text):
     prefix1 = phonemes(text.split()[1])[:dic[text.split()[1]] ]  # ['S', 'N']
     suffix1 = phonemes(text.split()[1])[ dic[text.split()[1]]:]  # ['AE1', 'K', 'S']
 
+    # If either word begins with a vowel sound, there's no leading consonant
+    # cluster to swap, so no spoonerism is possible.
+    if not prefix0 or not prefix1:
+        return
+
     print(prefix0,suffix0,prefix1,suffix1)
     # print(rhymesdict[word])
     for word in text.split():  # ['trail', 'snacks']
@@ -92,12 +97,18 @@ def sentence(sentence):
 
         if results:
             combos = [x for x in itertools.product(results[pair[0]], results[pair[1]])]
-            pair_sentences = [
-                sentence.replace(pair[0], combos[x][0], 1).replace(
-                    pair[1], combos[x][1], 1
-                )
-                for x in range(len(combos))
-            ]
+            pair_sentences = []
+            for first, second in combos:
+                words = sentence.split()
+                for idx, word in enumerate(words):
+                    if word == pair[0]:
+                        words[idx] = first
+                        break
+                for idx, word in enumerate(words):
+                    if word == pair[1]:
+                        words[idx] = second
+                        break
+                pair_sentences.append(" ".join(words))
         else:
             continue  # pragma: no cover
         sentences.extend(sorted(pair_sentences))


### PR DESCRIPTION
## Summary
- add a lightweight pkg_resources shim and declare setuptools so pronouncing can load packaged data
- avoid generating spoonerisms when a word starts with a vowel and replace words safely in sentences
- refresh dependency input/output files to include setuptools

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e050fc7dc8327819a5f92a80a85bf)