### PR TITLE
Add Flask web interface for spoonerisms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = ""
 description-file = "README.md"
 home-page = "https://github.com/danmaps/spooner"
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires=["pronouncing", "setuptools"]
+requires=["pronouncing", "setuptools", "flask"]
 
 [tool.flit.metadata.requires-extra]
 test = ["pytest", "pytest-cov", "tox"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 nltk
 pronouncing
 setuptools
+flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile requirements.in
 #
 cmudict==0.4.3            # via pronouncing
+flask
 nltk
 pronouncing==0.2.0
 setuptools

--- a/spooner/__init__.py
+++ b/spooner/__init__.py
@@ -5,4 +5,5 @@ __version__ = "0.5.11"
 
 from .spooner import phonemes  # noqa
 from .spooner import spoon  # noqa
+from .spooner import spoon_details  # noqa
 from .spooner import sentence  # noqa

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,127 @@
+const form = document.getElementById("spoon-form");
+const steps = document.getElementById("steps");
+const details = document.getElementById("details");
+const errorBox = document.getElementById("error");
+
+const createStep = (label, content, highlight = false) => {
+  const wrapper = document.createElement("div");
+  wrapper.className = "step animate-in";
+
+  const small = document.createElement("small");
+  small.textContent = label;
+  const body = document.createElement("div");
+  body.className = "content" + (highlight ? " swap" : "");
+  body.textContent = content;
+
+  wrapper.appendChild(small);
+  wrapper.appendChild(body);
+  steps.appendChild(wrapper);
+};
+
+const formatPhonemes = (collection) =>
+  collection.map((line) => line.join(" ")).join("  |  ");
+
+const renderDetails = (data) => {
+  details.innerHTML = "";
+  const tiles = [
+    {
+      title: "Original",
+      body: data.original_words.join(" → "),
+    },
+    {
+      title: "Phonemes",
+      body: formatPhonemes(data.phonemes),
+    },
+    {
+      title: "Swapped",
+      body: data.swapped_phonemes.map((p) => p.join(" ")).join("  |  "),
+    },
+  ];
+
+  if (data.sample_result.length) {
+    tiles.push({
+      title: "Result",
+      body: data.sample_result.join(" → "),
+    });
+  }
+
+  tiles.forEach((tile) => {
+    const card = document.createElement("div");
+    card.className = "tile";
+    const title = document.createElement("h3");
+    title.textContent = tile.title;
+    const body = document.createElement("p");
+    body.textContent = tile.body;
+    card.appendChild(title);
+    card.appendChild(body);
+    details.appendChild(card);
+  });
+};
+
+const renderSteps = (data) => {
+  steps.innerHTML = "";
+  const [first, second] = data.original_words;
+  const sequence = [
+    {
+      label: "Words",
+      content: `${first} + ${second}`,
+    },
+    {
+      label: "Phonemes",
+      content: data.phonemes.map((p) => p.join(" ")).join("  |  "),
+    },
+    {
+      label: "Sound swap",
+      content: data.swapped_phonemes.map((p) => p.join(" ")).join("  |  "),
+      highlight: true,
+    },
+    {
+      label: "Spoonerism",
+      content:
+        data.sample_result.length > 0
+          ? data.sample_result.join(" + ")
+          : "No matches found yet.",
+    },
+  ];
+
+  sequence.forEach((item, idx) => {
+    setTimeout(() => {
+      createStep(item.label, item.content, item.highlight);
+    }, idx * 520);
+  });
+};
+
+const showError = (message) => {
+  errorBox.textContent = message;
+};
+
+const handleSubmit = async (event) => {
+  event.preventDefault();
+  const phrase = new FormData(form).get("phrase");
+  steps.innerHTML = "";
+  details.innerHTML = "";
+  showError("");
+
+  try {
+    const response = await fetch("/api/spoon", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ phrase }),
+    });
+
+    const payload = await response.json();
+    if (!response.ok) {
+      showError(payload.error || "Unable to build a spoonerism.");
+      return;
+    }
+
+    renderSteps(payload);
+    renderDetails(payload);
+  } catch (err) {
+    showError("Something went wrong. Try again.");
+  }
+};
+
+form.addEventListener("submit", handleSubmit);

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,232 @@
+:root {
+  --bg: #0b1021;
+  --surface: #111a32;
+  --accent: #8ef0c0;
+  --text: #e7ecf7;
+  --muted: #9fb0d0;
+  --border: #1f2a48;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, #18254a, #0b1021 40%),
+    radial-gradient(circle at 80% 0%, #1d2c50, #0b1021 40%),
+    var(--bg);
+  color: var(--text);
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  align-items: center;
+}
+
+h1 {
+  margin: 8px 0 12px;
+  font-size: clamp(28px, 4vw, 40px);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--accent);
+  font-weight: 700;
+  margin: 0;
+}
+
+.lede {
+  margin: 0;
+  color: var(--muted);
+  max-width: 620px;
+}
+
+.card,
+.panel {
+  background: rgba(17, 26, 50, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 20px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(6px);
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.input-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+}
+
+input {
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0f162c;
+  color: var(--text);
+  font-size: 16px;
+}
+
+input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+button {
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(90deg, #7fe7ff, #8ef0c0);
+  color: #04202e;
+  font-weight: 700;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.help,
+.muted {
+  color: var(--muted);
+  margin: 10px 0 0;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.steps {
+  display: grid;
+  gap: 12px;
+}
+
+.step {
+  padding: 14px;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+}
+
+.step small {
+  display: block;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.step .content {
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.animate-in {
+  animation: fadeIn 0.4s ease;
+}
+
+.swap {
+  color: var(--accent);
+  position: relative;
+}
+
+.swap::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 2px;
+  background: var(--accent);
+  animation: slide 1.1s ease infinite;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide {
+  from {
+    width: 10%;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.tile {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.tile h3 {
+  margin: 0 0 6px;
+}
+
+.tile p {
+  margin: 0;
+}
+
+#error {
+  min-height: 20px;
+}
+
+@media (max-width: 640px) {
+  .input-row {
+    grid-template-columns: 1fr;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spoonerism Playground</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="page">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Spooner</p>
+          <h1>Trade sounds and watch the swap happen.</h1>
+          <p class="lede">
+            Enter two words to see their phonemes, watch the sound swap animation,
+            and get a spoonerism suggestion.
+          </p>
+        </div>
+        <form id="spoon-form" class="card">
+          <label for="phrase">Two words</label>
+          <div class="input-row">
+            <input
+              type="text"
+              id="phrase"
+              name="phrase"
+              placeholder="trail snacks"
+              autocomplete="off"
+              required
+            />
+            <button type="submit">Spoon it</button>
+          </div>
+          <p class="help">Use everyday words for the best results.</p>
+        </form>
+      </header>
+
+      <section class="panels">
+        <div class="panel" id="timeline">
+          <div class="panel-header">
+            <h2>Animation</h2>
+            <p class="muted">Words → phonemes → swapped sounds → results</p>
+          </div>
+          <div class="steps" id="steps"></div>
+        </div>
+
+        <div class="panel" id="results">
+          <div class="panel-header">
+            <h2>Details</h2>
+            <p class="muted">Raw phonemes and sample spoonerism</p>
+          </div>
+          <div class="grid" id="details"></div>
+          <p class="muted" id="error" role="status"></p>
+        </div>
+      </section>
+    </main>
+
+    <script src="{{ url_for('static', filename='app.js') }}" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a helper that exposes spoonerism construction details and export it from the package
- build a small Flask app with an API endpoint and animated UI for exploring sound swaps
- include static assets and dependency updates for the web demo

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e07d35a1483278328e8e9492ae9d0)