### PR TITLE
Improve README with project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 
 # spooner
 
-Generates [spoonerisms](https://en.wikipedia.org/wiki/Spoonerism) based on sounds in words. 
+Generates [spoonerisms](https://en.wikipedia.org/wiki/Spoonerism) by swapping phonemes instead of just letters. The package ships a small Flask playground so you can watch the sound swap happen in the browser.
 
 | STANDARD DISCLAIMER: Spoonerisms made by this program are not guaranteed to be funny, but they *are* technically spoonerisms. |
 | --- | 
 
 
 Inspired by [a great podcast episode](https://testandcode.com/80), I created this to learn about packaging, flit, tox, pytest, and coverage. I also threw in a few learning experiences related to  Azure pipelines and black. It went surprisingly well, so now I have a thing that lives on the internet. Anyone can install and play with it! Neat!
+
+Under the hood, Spooner leans on the [CMU Pronouncing Dictionary](http://www.speech.cs.cmu.edu/cgi-bin/cmudict) via the `pronouncing` library. Each word is broken into its ARPAbet phonemes, the leading consonant clusters are swapped, and only outputs that exist in the dictionary are returned. That means the results are real words instead of random letter jumbles. When a word is missing from the dictionary, you’ll get a friendly error so you can try something more common.
 
 
 ## Installation
@@ -37,5 +39,20 @@ Use it like this:
 ~~~
 >>> sp.sentence("let's eat trail snacks")
 ["let's treat ail snacks", "let's treat ale snacks", "let's eat snail tracks", "let's eat snail trax"]
+~~~
+
+`spoon_details` is handy when you want to show *how* a spoonerism was built:
+
+~~~
+>>> sp.spoon_details("trail snacks")
+{'original_words': ['trail', 'snacks'], 'phonemes': [['T', 'R', 'EY1', 'L'], ['S', 'N', 'AE1', 'K', 'S']], 'swapped_phonemes': [['S', 'N', 'EY1', 'L'], ['T', 'R', 'AE1', 'K', 'S']], 'spoonerisms': {'trail': ['snail'], 'snacks': ['tracks', 'trax']}, 'sample_result': ['snail', 'tracks']}
+~~~
+
+### Experimental web front end
+
+There is a tiny Flask app (`spooner.webapp`) that powers a static front end in `templates/` and `static/`. Start it locally to type in two words, animate the phoneme swap, and view the raw phoneme breakdown. It’s intentionally minimal—there’s no persistence or user accounts—but it demonstrates how the API response can drive UI animations.
+
+~~~
+FLASK_APP=spooner.webapp flask run
 ~~~
 


### PR DESCRIPTION
## Summary
- clarify how spooner builds phoneme-based spoonerisms using the pronouncing dictionary
- expand usage guidance with spoon_details output example
- document the experimental Flask front end and how to start it

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e0d4b80a08327a8e218a067ba8488)